### PR TITLE
removing old setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,45 @@ helix push dev
 
 > Note: Because we already have [helix.toml](./helix.toml) defined, we don't need to run `helix init`
 
+5) Install ffmpeg/ffprobe and verify PATH
 
-6) Start the Electron app
+macOS (Homebrew):
 
 ```bash
+brew install ffmpeg
+```
+
+Ubuntu/Debian:
+
+```bash
+sudo apt update && sudo apt install -y ffmpeg
+```
+
+Windows (winget):
+
+```powershell
+winget install --id Gyan.FFmpeg -e
+```
+
+Verify both binaries are available:
+
+```bash
+ffmpeg -version
+ffprobe -version
+```
+
+
+6) Run locally
+
+```bash
+# one-time
 npm --prefix client install
-npm --prefix client run sidecar:build:debug
-npm --prefix client run dev
+
+# terminal 1
+cargo run
+
+# terminal 2
+npm --prefix client run dev:rust-core
 ```
 
 ## Runtime modes (rewrite migration)


### PR DESCRIPTION
## Description
Removing non-rust sidecar instructions from contributing docs.

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [X] No compiler warnings (if applicable)
- [X] Code is formatted with `rustfmt`, `ty`
- [X] No useless or dead code (if applicable)
- [X] Code is easy to understand
- [X] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [X] All tests pass
- [X] Performance has not regressed (assuming change was not to fix a bug)

